### PR TITLE
🐛 Fix single char strings returning an empty string

### DIFF
--- a/ClrDebug/Managed/Cordb/Value/CorDebugStringValue.cs
+++ b/ClrDebug/Managed/Cordb/Value/CorDebugStringValue.cs
@@ -78,7 +78,7 @@ namespace ClrDebug
             HRESULT hr = Raw.GetString(cchString, out pcchString, szString);
 
             if (hr == HRESULT.S_OK)
-                szStringResult = CreateString(szString, pcchString);
+                szStringResult = CreateString(szString, pcchString + 1);
             else
                 szStringResult = default(string);
 


### PR DESCRIPTION
`pcchString` from `HRESULT hr = Raw.GetString(cchString, out pcchString, szString);` returns "A pointer to the number of characters returned in the szString array"
This is actually excluding the null terminating character however.
So for 
`cchString` = 2
`chArray.Length` = 2
`pcchString` = 1

`Extensions.CreateString`:
`/// <param name="length">The number of characters that were filled in in <paramref name="charArray" /> including a null-terminator (\0).</param>`

Based on this description, we need to add one to `pcchString` before passing it to `Extensions.CreateString`, or alternatively, just pass the user supplied `cchString`