### PR TITLE
Add [PreserveSig] on IMetaDataImport.IsValidToken()

### DIFF
--- a/ClrDebug/Managed/Metadata/MetaDataImport.cs
+++ b/ClrDebug/Managed/Metadata/MetaDataImport.cs
@@ -3007,7 +3007,8 @@ namespace ClrDebug
         /// <param name="tk">[in] The token to check the reference validity for.</param>
         public bool IsValidToken(mdToken tk)
         {
-            /*bool IsValidToken(
+            /*[PreserveSig]
+            bool IsValidToken(
             [In] mdToken tk);*/
             return Raw.IsValidToken(tk);
         }

--- a/ClrDebug/Managed/Metadata/MetaDataImport.cs
+++ b/ClrDebug/Managed/Metadata/MetaDataImport.cs
@@ -3007,8 +3007,7 @@ namespace ClrDebug
         /// <param name="tk">[in] The token to check the reference validity for.</param>
         public bool IsValidToken(mdToken tk)
         {
-            /*[PreserveSig]
-            bool IsValidToken(
+            /*bool IsValidToken(
             [In] mdToken tk);*/
             return Raw.IsValidToken(tk);
         }

--- a/ClrDebug/Native/Interfaces/DbgEng/Model/IDataModelScriptDebugBreakpoint.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Model/IDataModelScriptDebugBreakpoint.cs
@@ -30,6 +30,7 @@ namespace ClrDebug.DbgEng
         /// All breakpoints should be created in the enabled state.
         /// </summary>
         /// <returns>This method returns bool. The value is an indication of whether the breakpoint is enabled or not.</returns>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool IsEnabled();
 

--- a/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostContextExtensibility.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostContextExtensibility.cs
@@ -15,6 +15,7 @@ namespace ClrDebug.DbgEng
 #endif
     public partial interface IDebugHostContextExtensibility
     {
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool HasExtensionData(
             [In] int blobId);

--- a/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostFunctionLocalDetails2.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostFunctionLocalDetails2.cs
@@ -35,7 +35,8 @@ namespace ClrDebug.DbgEng
         new HRESULT GetArgumentPosition(
             [Out] out long argPosition);
 #endif
-        
+
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool IsInlineScope();
         

--- a/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostMemory4.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostMemory4.cs
@@ -126,7 +126,8 @@ namespace ClrDebug.DbgEng
         HRESULT GetPhysicalAddressLocation(
             [In] long physAddr,
             [Out] out Location pPhysicalAddressLocation);
-        
+
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool IsPhysicalAddressLocation(
             [In] ref Location pLocation);

--- a/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostMemory5.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Model/IDebugHostMemory5.cs
@@ -126,7 +126,8 @@ namespace ClrDebug.DbgEng
         new HRESULT GetPhysicalAddressLocation(
             [In] long physAddr,
             [Out] out Location pPhysicalAddressLocation);
-        
+
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         new bool IsPhysicalAddressLocation(
             [In] ref Location pLocation);

--- a/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcBreakpointControllerAdvanced.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcBreakpointControllerAdvanced.cs
@@ -27,6 +27,7 @@ namespace ClrDebug.DbgEng
         /// This method returning "true" indicates that the values returned reflect the hardware without any such "adjustments" applied.<para/>
         /// This method returning "false" indicates the Windows behavior where the context record (&amp; trap frame) @pc refer to an instruction *AFTER* the "BRK ...".
         /// </summary>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool DoesBreakpointTrapAddressReflectHardware();
     }

--- a/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcBreakpointControllerAdvanced2.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcBreakpointControllerAdvanced2.cs
@@ -25,6 +25,7 @@ namespace ClrDebug.DbgEng
         /// This method returning "true" indicates that the values returned reflect the hardware without any such "adjustments" applied.<para/>
         /// This method returning "false" indicates the Windows behavior where the context record (&amp; trap frame) @pc refer to an instruction *AFTER* the "BRK ...".
         /// </summary>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         new bool DoesBreakpointTrapAddressReflectHardware();
 #endif

--- a/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcExceptionControl.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcExceptionControl.cs
@@ -28,6 +28,7 @@ namespace ClrDebug.DbgEng
         /// <summary>
         /// Indicates whether this exception will be passed onto the target or will be considered handled by the halt.
         /// </summary>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool WillPassToTarget();
 

--- a/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcTargetOperation.cs
+++ b/ClrDebug/Native/Interfaces/DbgEng/Services/ISvcTargetOperation.cs
@@ -39,6 +39,7 @@ namespace ClrDebug.DbgEng
         /// If the operation can be canceled, it will be canceled. The semantic meaning of a cancellation depends on the operation in question.<para/>
         /// For instance For a halt : the target will no longer be halted For a breakpoint: the breakpoint will be cleared.
         /// </summary>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.U1)]
         bool Cancel();
 

--- a/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport.cs
+++ b/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport.cs
@@ -1249,6 +1249,12 @@ namespace ClrDebug
         /// </summary>
         /// <param name="tk">[in] The token to check the reference validity for.</param>
         /// <returns>true if tk is a valid metadata token within the current scope. Otherwise, false.</returns>
+        /// <remarks>
+        /// The native method returns BOOL directly rather than an HRESULT, so this declaration must be
+        /// [PreserveSig]; without it the marshaller assumes an HRESULT-plus-retval shape and returns
+        /// uninitialized memory.
+        /// </remarks>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.Bool)]
         bool IsValidToken(
             [In] mdToken tk);

--- a/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport.cs
+++ b/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport.cs
@@ -1249,11 +1249,6 @@ namespace ClrDebug
         /// </summary>
         /// <param name="tk">[in] The token to check the reference validity for.</param>
         /// <returns>true if tk is a valid metadata token within the current scope. Otherwise, false.</returns>
-        /// <remarks>
-        /// The native method returns BOOL directly rather than an HRESULT, so this declaration must be
-        /// [PreserveSig]; without it the marshaller assumes an HRESULT-plus-retval shape and returns
-        /// uninitialized memory.
-        /// </remarks>
         [PreserveSig]
         [return: MarshalAs(UnmanagedType.Bool)]
         bool IsValidToken(

--- a/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport2.cs
+++ b/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport2.cs
@@ -1245,11 +1245,6 @@ namespace ClrDebug
         /// </summary>
         /// <param name="tk">[in] The token to check the reference validity for.</param>
         /// <returns>true if tk is a valid metadata token within the current scope. Otherwise, false.</returns>
-        /// <remarks>
-        /// The native method returns BOOL directly rather than an HRESULT, so this declaration must be
-        /// [PreserveSig]; without it the marshaller assumes an HRESULT-plus-retval shape and returns
-        /// uninitialized memory.
-        /// </remarks>
         [PreserveSig]
         [return: MarshalAs(UnmanagedType.Bool)]
         new bool IsValidToken(

--- a/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport2.cs
+++ b/ClrDebug/Native/Interfaces/Metadata/IMetaDataImport2.cs
@@ -1245,6 +1245,12 @@ namespace ClrDebug
         /// </summary>
         /// <param name="tk">[in] The token to check the reference validity for.</param>
         /// <returns>true if tk is a valid metadata token within the current scope. Otherwise, false.</returns>
+        /// <remarks>
+        /// The native method returns BOOL directly rather than an HRESULT, so this declaration must be
+        /// [PreserveSig]; without it the marshaller assumes an HRESULT-plus-retval shape and returns
+        /// uninitialized memory.
+        /// </remarks>
+        [PreserveSig]
         [return: MarshalAs(UnmanagedType.Bool)]
         new bool IsValidToken(
             [In] mdToken tk);

--- a/ClrDebug/Native/Interfaces/Symbols/IMetadataImportProvider.cs
+++ b/ClrDebug/Native/Interfaces/Symbols/IMetadataImportProvider.cs
@@ -23,7 +23,7 @@ namespace ClrDebug
         /// <remarks>
         /// The implementer is responsible for managing the lifetime of the resulting object.
         /// </remarks>
-        [return: MarshalAs(UnmanagedType.Interface)]
+        [return: MarshalAs(UnmanagedType.Interface)] //I'm not sure if this should be PreserveSig or not. I'm guessing the actual native implementation returns a HRESULT and emits the IMetaDataImport as an out parameter
         IMetaDataImport GetMetadataImport();
     }
 }

--- a/ClrDebug/Native/Interfaces/TTD/ILiveRecorder.cs
+++ b/ClrDebug/Native/Interfaces/TTD/ILiveRecorder.cs
@@ -113,6 +113,7 @@ namespace ClrDebug.TTD
         // If the calling thread wasn't recording because recording never was started,
         // or because recording was already explicitly stopped via this function,
         // then the result will be InstructionCount::Zero.
+        [PreserveSig]
         InstructionCount StopRecordingCurrentThread();
 
         // Query the current instruction counts relevant to the throttle.


### PR DESCRIPTION
Disclaimer: found by AI

IMetaDataImport::IsValidToken is one of the rare COM methods that natively
returns BOOL directly instead of an HRESULT. From cor.h:

    STDMETHOD_(BOOL, IsValidToken)(         // True or False.
        mdToken     tk) PURE;               // [IN] Given token.

ClrDebug declares it without [PreserveSig]:

    [return: MarshalAs(UnmanagedType.Bool)]
    bool IsValidToken(
        [In] mdToken tk);

Without [PreserveSig], both of ClrDebug's interop modes assume the standard
HRESULT-swapped shape, i.e. a native signature of

    HRESULT IsValidToken(mdToken tk, BOOL* retVal);

and call it with a phantom retval out-parameter. The real native method never
writes through that pointer (it doesn't know it exists), so the managed bool
comes back as whatever happened to be in that memory:

  * The BOOL that the native method actually returns (in eax/w0) is
    reinterpreted as the HRESULT: valid tokens produce 1 (S_FALSE), invalid
    tokens produce 0 (S_OK). Neither is a failure code, so nothing throws and
    the real answer is silently discarded.
  * The returned bool is read from the never-written out-slot: uninitialized
    stack memory.

In practice this read true-by-luck on Windows x64 for years. On macOS arm64
(net8.0 build, source-generated COM against mscordbi's metadata importer) the
slot reliably reads 0, so IsValidToken returns false for every token.

Both declarations are affected: IMetaDataImport.cs and the shadowing `new`
redeclaration in IMetaDataImport2.cs. The managed wrapper
(MetaDataImport.IsValidToken) forwards to the raw call, so it inherits the
garbage.

How we hit it
-------------
We host ClrDebug 0.4.1 (net8.0, GENERATED_MARSHALLING) on macOS arm64 inside a
managed debugger over dbgshim/mscordbi. Our metadata layer gates method-token
lookups on IsValidToken; on mac every call returned false, which made every
property-getter MethodInfo construction throw ArgumentException and killed all
static-field/property evaluation. Replacing the call with a manual vtable
invocation (slot 61, `delegate* unmanaged[Stdcall]<IntPtr, int, int>`, pointer
obtained via ComWrappers.TryGetComInstance) returns correct results against
the same importer instance, confirming the marshalling shape is the only
problem.

Fix
---
Add [PreserveSig] to both declarations:

    [PreserveSig]
    [return: MarshalAs(UnmanagedType.Bool)]
    bool IsValidToken(
        [In] mdToken tk);

This is the pattern ClrDebug already uses for other direct-BOOL methods
(ILiveRecorder.IsOpen, ISvcLegacyClrInformation.SupportsManagedStackUnwind).

Verified:
  * The .NET 8+ ComInterfaceGenerator accepts [PreserveSig] with a
    [return: MarshalAs(UnmanagedType.Bool)] bool return and emits the correct
    direct-return stub:
        var __target = (delegate* unmanaged[MemberFunction]<void*, int, int>)__vtable[slot];
        __retVal_native = __target(__this, tk);
        __retVal = __retVal_native != 0;
    (No phantom out-parameter; the CCW side marshals bool -> int 0/1
    symmetrically.)
  * The netstandard2.0 [ComImport] build compiles with the change and classic
    interop handles [PreserveSig] bool returns correctly.
  * On macOS arm64 against a live mscordbi metadata importer, the fixed shape
    returns correct validity for both valid and invalid tokens.

Possibly affected siblings (same shape, unverified)
---------------------------------------------------
A quick scan finds other direct bool-returning declarations that lack
[PreserveSig]. The underlying native methods (DbgModel.h / debugger services)
also return bool directly, so these look like the same bug:

    DbgEng/Model/IDebugHostContextExtensibility.HasExtensionData        (U1)
    DbgEng/Model/IDebugHostFunctionLocalDetails2.IsInlineScope          (U1)
    DbgEng/Model/IDebugHostMemory4.IsPhysicalAddressLocation            (U1)
    DbgEng/Model/IDebugHostMemory5.IsPhysicalAddressLocation (new)      (U1)
    DbgEng/Model/IDataModelScriptDebugBreakpoint.IsEnabled              (U1)
    DbgEng/Services/ISvcBreakpointControllerAdvanced.DoesBreakpointTrapAddressReflectHardware       (U1)
    DbgEng/Services/ISvcBreakpointControllerAdvanced2.DoesBreakpointTrapAddressReflectHardware (new) (U1)
    DbgEng/Services/ISvcTargetOperation.Cancel                          (U1)
    DbgEng/Services/ISvcExceptionControl.WillPassToTarget               (U1)

We only tested IsValidToken, so the attached change fixes just that one; the
list above may deserve the same treatment.